### PR TITLE
Allow Tracery to scan a simple plaintext file to generate rules

### DIFF
--- a/Common/Tracery.Eval.swift
+++ b/Common/Tracery.Eval.swift
@@ -19,7 +19,7 @@ extension Tracery {
         let nodes = try Parser.gen(Lexer.tokens(text))
         let output = try eval(nodes)
         
-        trace("📘 ouptut \(text) ==> \(output)")
+        trace("📘 output \(text) ==> \(output)")
         return output
     }
     

--- a/Common/Tracery.Text.swift
+++ b/Common/Tracery.Text.swift
@@ -1,0 +1,181 @@
+//
+//  Tracery.Text.swift
+//  Tracery
+//
+//  Created by Benzi on 21/03/17.
+//  Copyright © 2017 Benzi Ahamed. All rights reserved.
+//
+
+import Foundation
+
+
+// File format that can scan plain text
+
+extension Tracery {
+    
+    convenience public init(path: String) {
+        if let reader = StreamReader(path: path) {
+            self.init { TextParser.parse(lines: reader) }
+        }
+        else {
+            warn("unable to parse input file: \(path)")
+            self.init()
+        }
+    }
+    
+    convenience public init(lines: [String]) {
+        self.init { TextParser.parse(lines: lines) }
+    }
+    
+}
+
+struct TextParser {
+    
+    enum State {
+        case consumeRule
+        case consumeDefinitions
+    }
+    
+    static func parse<S: Sequence>(lines: S) -> [String: Any] where S.Iterator.Element == String {
+        
+        var ruleSet = [String: Any]()
+        var state = State.consumeRule
+        var rule = ""
+        var candidates = [String]()
+        
+        func createRule() {
+            if ruleSet[rule] != nil {
+                warn("rule '\(rule)' defined twice, will be overwritten")
+            }
+            if candidates.count == 0 {
+                candidates.append("")
+            }
+            ruleSet[rule] = candidates
+        }
+        
+        for line in lines {
+            switch state {
+            case .consumeRule:
+                if line.characters.count > 2, line.hasPrefix("["), line.hasSuffix("]") {
+                    let start = line.index(after: line.startIndex)
+                    let end = line.index(before: line.endIndex)
+                    rule = line.substring(with: start..<end)
+                    state = .consumeDefinitions
+                }
+            case .consumeDefinitions:
+                if line == "" {
+                    createRule()
+                    candidates.removeAll()
+                    state = .consumeRule
+                }
+                else {
+                    candidates.append(line)
+                }
+            }
+        }
+        // if we reached the end, and
+        // we are in the midst of consuming
+        // definitions, create a rule
+        if state == .consumeDefinitions  {
+            createRule()
+        }
+        
+        return ruleSet
+    }
+    
+}
+
+class StreamReader  {
+    
+    let encoding : String.Encoding
+    let chunkSize : Int
+    
+    var fileHandle : FileHandle!
+    let buffer : NSMutableData!
+    let delimData : Data!
+    var atEof : Bool = false
+    
+    init?(path: String, delimiter: String = "\n", encoding: String.Encoding = .utf8, chunkSize : Int = 4096) {
+        self.chunkSize = chunkSize
+        self.encoding = encoding
+        
+        if let fileHandle = FileHandle(forReadingAtPath: path),
+            let delimData = delimiter.data(using: encoding),
+            let buffer = NSMutableData(capacity: chunkSize)
+        {
+            self.fileHandle = fileHandle
+            self.delimData = delimData
+            self.buffer = buffer
+        } else {
+            self.fileHandle = nil
+            self.delimData = nil
+            self.buffer = nil
+            return nil
+        }
+    }
+    
+    deinit {
+        self.close()
+    }
+    
+    /// Return next line, or nil on EOF.
+    func nextLine() -> String? {
+        precondition(fileHandle != nil, "Attempt to read from closed file")
+        
+        if atEof {
+            return nil
+        }
+        
+        // Read data chunks from file until a line delimiter is found:
+        var range = buffer.range(of: delimData, options: [], in: NSMakeRange(0, buffer.length))
+        while range.location == NSNotFound {
+            let tmpData = fileHandle.readData(ofLength: chunkSize)
+            if tmpData.count == 0 {
+                // EOF or read error.
+                atEof = true
+                if buffer.length > 0 {
+                    // Buffer contains last line in file (not terminated by delimiter).
+                    let line = String(data: buffer as Data, encoding: encoding)
+                    
+                    buffer.length = 0
+                    return line as String?
+                }
+                // No more lines.
+                return nil
+            }
+            buffer.append(tmpData)
+            range = buffer.range(of: delimData, options: [], in: NSMakeRange(0, buffer.length))
+        }
+        
+        // Convert complete line (excluding the delimiter) to a string:
+        let line = String(data: buffer.subdata(with: NSMakeRange(0, range.location)),
+                            encoding: encoding)
+        // Remove line (and the delimiter) from the buffer:
+        buffer.replaceBytes(in: NSMakeRange(0, range.location + range.length), withBytes: nil, length: 0)
+        
+        return line
+    }
+    
+    /// Start reading from the beginning of file.
+    func rewind() -> Void {
+        fileHandle.seek(toFileOffset: 0)
+        buffer.length = 0
+        atEof = false
+    }
+    
+    /// Close the underlying file. No reading must be done after calling this method.
+    func close() -> Void {
+        fileHandle?.closeFile()
+        fileHandle = nil
+    }
+}
+
+extension StreamReader: Sequence {
+    func makeIterator() -> AnyIterator<String> {
+        return AnyIterator<String> {
+            return self.nextLine()
+        }
+    }
+}
+
+

--- a/CommonTesting/TextFormat.swift
+++ b/CommonTesting/TextFormat.swift
@@ -43,4 +43,15 @@ class TextFormat: XCTestCase {
 
     }
     
+    func testPlaintextFile() {
+        
+        let fableFile = Bundle(for: type(of: self)).path(forResource: "fable", ofType: "txt")!
+        let t = Tracery.init(path: fableFile)
+        
+        for _ in 0..<10 {
+            XCTAssertFalse(t.expand("#fable#").isEmpty)
+        }
+        
+    }
+    
 }

--- a/CommonTesting/TextFormat.swift
+++ b/CommonTesting/TextFormat.swift
@@ -1,0 +1,46 @@
+//
+//  TextFormat.swift
+//  Tracery
+//
+//  Created by Benzi on 21/03/17.
+//  Copyright © 2017 Benzi Ahamed. All rights reserved.
+//
+
+import XCTest
+@testable import Tracery
+
+class TextFormat: XCTestCase {
+
+    
+    func testPlaintextFormat() {
+     
+        let lines = [
+            "[origin]",
+            "hello world",
+        ]
+        
+        let t = Tracery(lines: lines)
+        
+        XCTAssertEqual(t.expand("#origin#"), "hello world")
+        
+    }
+    
+    
+    func testPlaintextFormatAllowsEmptyRuleCreation() {
+
+        let lines = [
+            "[binary]",
+            "0#binary#",
+            "1#binary#",
+            "#empty#",
+            "",
+            "[empty]",
+            ]
+        
+        let t = Tracery(lines: lines)
+        
+        XCTAssertFalse(t.expandVerbose("#binary#").contains("stack overflow"))
+
+    }
+    
+}

--- a/CommonTesting/fable.txt
+++ b/CommonTesting/fable.txt
@@ -1,0 +1,31 @@
+[fable]
+#the# #adjective# #noun#
+#the# #noun#
+#the# #noun# Who #verb# The #adjective# #noun#
+
+[the]
+The
+The Strange Story of The
+The Tale of The
+A
+The Origin of The
+
+[adjective]
+Lonely
+Missing
+Greedy
+Valiant
+Blind
+
+[noun]
+Hare
+Hound
+Beggar
+Lion
+Frog
+
+[verb]
+Finds
+Meets
+Tricks
+Outwits

--- a/Playgrounds/Tracery.playground/Pages/Advanced Conditionals.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/Tracery.playground/Pages/Advanced Conditionals.xcplaygroundpage/Contents.swift
@@ -1,7 +1,5 @@
 //: [Previous](@previous)
 
-import Foundation
-import Tracery
 
 /*:
  
@@ -22,6 +20,10 @@ import Tracery
  
  
  */
+
+import Foundation
+import Tracery
+
 
 var t = Tracery {[
     
@@ -51,5 +53,70 @@ t.expand("#msg_if_zero#")
 // print out a number that does not contain digits 0 or 1
 t.expand("[while #[d:#digit#]d# not in #binary# do #d#]")
 
+
+/*:
+ 
+ ## Text Format
+ 
+ Tracery can recognize rules defined in plain text files as well. The file must contain a set of rule definitions, with the rule specified inside square brackets, and its expansion candidates defined one per line. Here is a sample file:
+ 
+```
+[binary]
+0#binary#
+1#binary#
+#empty#
+ 
+[empty]
+```
+ The above file is a basic binary number generator.
+ Here's another one for fable names.
+ 
+```
+[fable]
+#the# #adjective# #noun#
+#the# #noun#
+#the# #noun# Who #verb# The #adjective# #noun#
+ 
+[the]
+The
+The Strange Story of The
+The Tale of The
+A
+The Origin of The
+ 
+[adjective]
+Lonely
+Missing
+Greedy
+Valiant
+Blind
+ 
+[noun]
+Hare
+Hound
+Beggar
+Lion
+Frog
+ 
+[verb]
+Finds
+Meets
+Tricks
+Outwits
+```
+ 
+ This input file will generate output like:
+ 
+```
+ A Greedy Frog
+ The Beggar
+ The Origin of The Hare Who Finds The Missing Lion
+ The Strange Story of The Hound
+ The Tale of The Blind Frog
+```
+ 
+ You use the `Tracery.init(path:)` constructor to consume rules from a plain text file.
+ 
+ */
 
 //: [Conclusion](@next)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
     - [Control Flow](#control-flow)
         - [if block](#if-block)
         - [while block](#while-block)
+    - [Text Format](#text-format)
 - [Tracery Grammar](#tracery-grammar)
 - [Conclusion](#conclusion)
  
@@ -928,11 +929,6 @@ h.expand("#origin#")
 ```
 
 
-```swift
-import Foundation
-import Tracery
-```
-
 
 
  
@@ -959,6 +955,10 @@ import Tracery
 
 
 ```swift
+import Foundation
+import Tracery
+
+
 var t = Tracery {[
     
     "digit" : [0,1,2,3,4,5,6,7,8,9],
@@ -989,8 +989,78 @@ t.expand("#msg_if_zero#")
 ```swift
 // print out a number that does not contain digits 0 or 1
 t.expand("[while #[d:#digit#]d# not in #binary# do #d#]")
-
 ```
+
+
+
+
+ 
+
+[top](#contents)
+****
+
+## Text Format
+ 
+ Tracery can recognize rules defined in plain text files as well. The file must contain a set of rule definitions, with the rule specified inside square brackets, and its expansion candidates defined one per line. Here is a sample file:
+ 
+```
+[binary]
+0#binary#
+1#binary#
+#empty#
+ 
+[empty]
+```
+ The above file is a basic binary number generator.
+ Here's another one for fable names.
+ 
+```
+[fable]
+#the# #adjective# #noun#
+#the# #noun#
+#the# #noun# Who #verb# The #adjective# #noun#
+ 
+[the]
+The
+The Strange Story of The
+The Tale of The
+A
+The Origin of The
+ 
+[adjective]
+Lonely
+Missing
+Greedy
+Valiant
+Blind
+ 
+[noun]
+Hare
+Hound
+Beggar
+Lion
+Frog
+ 
+[verb]
+Finds
+Meets
+Tricks
+Outwits
+```
+ 
+ This input file will generate output like:
+ 
+```
+ A Greedy Frog
+ The Beggar
+ The Origin of The Hare Who Finds The Missing Lion
+ The Strange Story of The Hound
+ The Tale of The Blind Frog
+```
+ 
+ You use the `Tracery.init(path:)` constructor to consume rules from a plain text file.
+ 
+
 
 
 

--- a/Tracery/Tracery.xcodeproj/project.pbxproj
+++ b/Tracery/Tracery.xcodeproj/project.pbxproj
@@ -59,6 +59,10 @@
 		B96DC0321E72F2B7008623B8 /* Tracery.Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96DC0271E72F2B7008623B8 /* Tracery.Logging.swift */; };
 		B96DC0331E72F2B7008623B8 /* Tracery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96DC0281E72F2B7008623B8 /* Tracery.swift */; };
 		B975BB7E1E75C91C0076A1EA /* TagStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B975BB7D1E75C91C0076A1EA /* TagStorage.swift */; };
+		B9A248E61E817216004D60C9 /* Tracery.Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A248E51E817216004D60C9 /* Tracery.Text.swift */; };
+		B9A248E71E817216004D60C9 /* Tracery.Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A248E51E817216004D60C9 /* Tracery.Text.swift */; };
+		B9A248E91E81859A004D60C9 /* TextFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A248E81E81859A004D60C9 /* TextFormat.swift */; };
+		B9A248EA1E81859A004D60C9 /* TextFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A248E81E81859A004D60C9 /* TextFormat.swift */; };
 		B9FCA7F51E73D2D20069F8B6 /* CyclicReferenceIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96DC01E1E72F2B7008623B8 /* CyclicReferenceIdentifier.swift */; };
 		B9FCA7F61E73D2D20069F8B6 /* EmptyRulesetDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96DC01F1E72F2B7008623B8 /* EmptyRulesetDetector.swift */; };
 		B9FCA7F71E73D2D20069F8B6 /* Lexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96DC0201E72F2B7008623B8 /* Lexer.swift */; };
@@ -127,6 +131,8 @@
 		B96DC0271E72F2B7008623B8 /* Tracery.Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tracery.Logging.swift; sourceTree = "<group>"; };
 		B96DC0281E72F2B7008623B8 /* Tracery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tracery.swift; sourceTree = "<group>"; };
 		B975BB7D1E75C91C0076A1EA /* TagStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TagStorage.swift; sourceTree = "<group>"; };
+		B9A248E51E817216004D60C9 /* Tracery.Text.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tracery.Text.swift; sourceTree = "<group>"; };
+		B9A248E81E81859A004D60C9 /* TextFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFormat.swift; sourceTree = "<group>"; };
 		B9FCA8071E73D6FA0069F8B6 /* Tracery Tests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tracery Tests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9FCA80B1E73D6FA0069F8B6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -192,6 +198,7 @@
 				B91280091E77AF980063D5A8 /* Rules.swift */,
 				B912800A1E77AF980063D5A8 /* Tags.swift */,
 				B912800B1E77AF980063D5A8 /* TraceryioSamples.swift */,
+				B9A248E81E81859A004D60C9 /* TextFormat.swift */,
 			);
 			name = CommonTesting;
 			path = ../CommonTesting;
@@ -256,6 +263,7 @@
 				B96DC0281E72F2B7008623B8 /* Tracery.swift */,
 				B975BB7D1E75C91C0076A1EA /* TagStorage.swift */,
 				B90E7E741E77C6A000C5BD17 /* Tracery.Eval.swift */,
+				B9A248E51E817216004D60C9 /* Tracery.Text.swift */,
 			);
 			name = Common;
 			path = ../Common;
@@ -452,6 +460,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B91280401E77B0530063D5A8 /* CandidateSelector.swift in Sources */,
+				B9A248EA1E81859A004D60C9 /* TextFormat.swift in Sources */,
 				B91280441E77B0530063D5A8 /* ExtensionCalls.swift in Sources */,
 				B912803F1E77B0530063D5A8 /* CandidateProvider.swift in Sources */,
 				B91280411E77B0530063D5A8 /* CustomProviders.swift in Sources */,
@@ -476,6 +485,7 @@
 			files = (
 				B975BB7E1E75C91C0076A1EA /* TagStorage.swift in Sources */,
 				B96DC0331E72F2B7008623B8 /* Tracery.swift in Sources */,
+				B9A248E61E817216004D60C9 /* Tracery.Text.swift in Sources */,
 				B96DC02C1E72F2B7008623B8 /* Parser.swift in Sources */,
 				B96DC02F1E72F2B7008623B8 /* RuleSelfReferenceIdentifer.swift in Sources */,
 				B96DC02A1E72F2B7008623B8 /* EmptyRulesetDetector.swift in Sources */,
@@ -496,6 +506,7 @@
 			files = (
 				B953F8AE1E771704001D6052 /* TagStorage.swift in Sources */,
 				B9FCA7F51E73D2D20069F8B6 /* CyclicReferenceIdentifier.swift in Sources */,
+				B9A248E71E817216004D60C9 /* Tracery.Text.swift in Sources */,
 				B9FCA7F61E73D2D20069F8B6 /* EmptyRulesetDetector.swift in Sources */,
 				B9FCA7F71E73D2D20069F8B6 /* Lexer.swift in Sources */,
 				B9FCA7F81E73D2D20069F8B6 /* Parser.swift in Sources */,
@@ -515,6 +526,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B91280301E77B0520063D5A8 /* CandidateSelector.swift in Sources */,
+				B9A248E91E81859A004D60C9 /* TextFormat.swift in Sources */,
 				B91280341E77B0520063D5A8 /* ExtensionCalls.swift in Sources */,
 				B912802F1E77B0520063D5A8 /* CandidateProvider.swift in Sources */,
 				B91280311E77B0520063D5A8 /* CustomProviders.swift in Sources */,

--- a/Tracery/Tracery.xcodeproj/project.pbxproj
+++ b/Tracery/Tracery.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		B9A248E71E817216004D60C9 /* Tracery.Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A248E51E817216004D60C9 /* Tracery.Text.swift */; };
 		B9A248E91E81859A004D60C9 /* TextFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A248E81E81859A004D60C9 /* TextFormat.swift */; };
 		B9A248EA1E81859A004D60C9 /* TextFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A248E81E81859A004D60C9 /* TextFormat.swift */; };
+		B9A248EE1E818FC0004D60C9 /* fable.txt in Resources */ = {isa = PBXBuildFile; fileRef = B9A248EB1E818FB3004D60C9 /* fable.txt */; };
+		B9A248EF1E818FC0004D60C9 /* fable.txt in Resources */ = {isa = PBXBuildFile; fileRef = B9A248EB1E818FB3004D60C9 /* fable.txt */; };
 		B9FCA7F51E73D2D20069F8B6 /* CyclicReferenceIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96DC01E1E72F2B7008623B8 /* CyclicReferenceIdentifier.swift */; };
 		B9FCA7F61E73D2D20069F8B6 /* EmptyRulesetDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96DC01F1E72F2B7008623B8 /* EmptyRulesetDetector.swift */; };
 		B9FCA7F71E73D2D20069F8B6 /* Lexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96DC0201E72F2B7008623B8 /* Lexer.swift */; };
@@ -133,6 +135,7 @@
 		B975BB7D1E75C91C0076A1EA /* TagStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TagStorage.swift; sourceTree = "<group>"; };
 		B9A248E51E817216004D60C9 /* Tracery.Text.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tracery.Text.swift; sourceTree = "<group>"; };
 		B9A248E81E81859A004D60C9 /* TextFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFormat.swift; sourceTree = "<group>"; };
+		B9A248EB1E818FB3004D60C9 /* fable.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = fable.txt; sourceTree = "<group>"; };
 		B9FCA8071E73D6FA0069F8B6 /* Tracery Tests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tracery Tests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9FCA80B1E73D6FA0069F8B6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -199,6 +202,7 @@
 				B912800A1E77AF980063D5A8 /* Tags.swift */,
 				B912800B1E77AF980063D5A8 /* TraceryioSamples.swift */,
 				B9A248E81E81859A004D60C9 /* TextFormat.swift */,
+				B9A248EB1E818FB3004D60C9 /* fable.txt */,
 			);
 			name = CommonTesting;
 			path = ../CommonTesting;
@@ -426,6 +430,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B9A248EF1E818FC0004D60C9 /* fable.txt in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -449,6 +454,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B9A248EE1E818FC0004D60C9 /* fable.txt in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
You can now write up rules in a text file, and Tracery will parse those rules for you.

An example file for a binary number generator

```
[binary]
0#binary#
1#binary#
#empty#

[empty]
```