### PR TITLE
Add Swift Package Manager and Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ Tracery.xcworkspace/xcuserdata/*
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 .build/
+.swiftpm/
 
 # CocoaPods
 #

--- a/Common/RuleCandidateSelector.swift
+++ b/Common/RuleCandidateSelector.swift
@@ -29,7 +29,7 @@ private extension MutableCollection {
         guard c > 1 else { return }
         
         for (firstUnshuffled , unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
-            let d: Int = numericCast(arc4random_uniform(numericCast(unshuffledCount)))
+            let d = Int.random(in: 0..<unshuffledCount)
             guard d != 0 else { continue }
             let i = index(firstUnshuffled, offsetBy: d)
             swapAt(firstUnshuffled, i)
@@ -82,7 +82,7 @@ class WeightedSelector :  RuleCandidateSelector {
     }
     
     func pick(count: Int) -> Int {
-        let choice = Int(arc4random_uniform(sum))
+        let choice = Int.random(in: 0..<numericCast(sum))
         let i = index(choice: choice)
         // print("id: ", id, "weights: ", weights, "sum: ", sum, "choice: ", choice, "index: ", i)
         return i

--- a/Common/Tracery.Logging.swift
+++ b/Common/Tracery.Logging.swift
@@ -46,7 +46,7 @@ func error(_ message: @autoclosure () -> String) {
 }
 
 func trace(_ message: @autoclosure () -> String) {
-    Tracery.log(level: .verbose, message: message)
+    Tracery.log(level: .verbose, message: message())
 }
 
 

--- a/CommonTesting/CandidateProvider.swift
+++ b/CommonTesting/CandidateProvider.swift
@@ -30,7 +30,7 @@ class CandidateProvider: XCTestCase {
             let candidates = ["jack","jill"]
             func pick(count: Int) -> Int {
                 invokeCount += 1
-                return Int(arc4random_uniform(2))
+                return Int.random(in: 0..<2)
             }
         }
         

--- a/CommonTesting/CustomProviders.swift
+++ b/CommonTesting/CustomProviders.swift
@@ -26,7 +26,7 @@ class WeightedCandidateSet : RuleCandidatesProvider, RuleCandidateSelector {
     }
     
     func pick(count: Int) -> Int {
-        var choice = Int(arc4random_uniform(sum))
+        var choice = Int.random(in: 0..<numericCast(sum))
         var index = 0
         for weight in weights {
             choice = choice - weight

--- a/CommonTesting/TextFormat.swift
+++ b/CommonTesting/TextFormat.swift
@@ -45,7 +45,7 @@ class TextFormat: XCTestCase {
     
     func testPlaintextFile() {
         
-        let fableFile = Bundle(for: type(of: self)).path(forResource: "fable", ofType: "txt")!
+        let fableFile = Bundle.main.executablePath! + "/CommonTesting/fable.txt"
         let t = Tracery.init(path: fableFile)
         
         for _ in 0..<10 {

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Tracery",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "Tracery",
+            targets: ["Tracery"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "Tracery",
+            dependencies: [],
+            path: "Common"),
+        .testTarget(
+            name: "TraceryTests",
+            dependencies: ["Tracery"],
+            path: "CommonTesting"),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:4.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Alternatively to give it a test run, run the command:
 [top](#contents)
 ****
 
+### Swift Package Manager
+Use Swift Package Manager support in Xcode 11 (File > Swift Packages > Add Package Dependency...) to add the Swift package to your targets. Or add Tracery to your Package.swift file with the following:
+
+```swift
+.package(url: "https://github.com/BenziAhamed/Tracery.git", from: "0.0.2")
+```
+
+Then, add Tracery as a dependency to your target(s):
+```swift
+.target(name: "App", dependencies: [..., "Tracery"])
+```
+
 ## Basic usage
  
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@
 - The project builds `iOS` and `macOS` framework targets, which can be linked to your projects
 
 ### Cocoapods
-You want to add pod 'Tracery', '~> 0.0.1' similar to the following to your Podfile:
+You want to add pod 'Tracery', '~> 0.0.2' similar to the following to your Podfile:
 
 ```
 target 'MyApp' do
-  pod 'Tracery', '~> 0.0.1'
+  pod 'Tracery', '~> 0.0.2'
 end
 ```
 Then run a pod install inside your terminal, or from CocoaPods.app.

--- a/Tracery.podspec
+++ b/Tracery.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Tracery"
-  s.version      = "0.0.1"
+  s.version      = "0.0.2"
   s.summary      = "Powerful extensible content generation library inspired by Tracery.io"
 
   s.description  = <<-DESC

--- a/Tracery/Tracery Tests/CandidateProvider.swift
+++ b/Tracery/Tracery Tests/CandidateProvider.swift
@@ -30,7 +30,7 @@ class CandidateProvider: XCTestCase {
             let candidates = ["jack","jill"]
             func pick(count: Int) -> Int {
                 invokeCount += 1
-                return Int(arc4random_uniform(2))
+                return Int.random(in: 0..<2)
             }
         }
         

--- a/Tracery/Tracery Tests/CustomProviders.swift
+++ b/Tracery/Tracery Tests/CustomProviders.swift
@@ -36,7 +36,7 @@ class WeightedCandidateSet : RuleCandidatesProvider, RuleCandidateSelector {
     }
     
     func pick(count: Int) -> Int {
-        let choice = Int(arc4random_uniform(totalWeights) + 1) // since running weight start at 1
+        let choice = Int.random(in: 0...runningWeights)
         for weight in runningWeights {
             if choice <= weight.total {
                 return weight.target


### PR DESCRIPTION
Apps may wish to use Swift Package Manager rather than CocoaPods to integrate Tracery into their projects with official Swift package support coming in Xcode 11. Given the lack of platform-dependent code, this change also allows Tracery to be used in other Swift packages for Apple platforms and even Linux more easily than before.

I did the following:

* Fixed a compilation error in the logging code (may be related to Swift 5.1).
* Added a Package.swift file.
* Updated the .gitignore to include another dot-named directory that may be used by Swift Package Manager.
* Updated README.md to include installation instructions for SPM including directions for both a Package.swift and installation through Xcode 11’s Swift package support.
* Updated podspec version to 0.0.2.
* Fixed a unit test which failed because SPM doesn't currently handle static resources well.

This change will require a new release 0.0.2, so I updated the README with that in mind. I have verified that the Swift package works when included as a dependency in another Swift package compiled for Linux and Apple platforms.